### PR TITLE
fix sh squad spawn and scientist enum

### DIFF
--- a/SerpentsHand/EventHandler.cs
+++ b/SerpentsHand/EventHandler.cs
@@ -98,7 +98,7 @@ namespace SerpentsHand
 			bool CiAlive = Plugin.CountRoles(Smod2.API.Team.CHAOS_INSURGENCY) > 0;
 			bool ScpAlive = Plugin.CountRoles(Smod2.API.Team.SCP) > 0;
 			bool DClassAlive = Plugin.CountRoles(Smod2.API.Team.CLASSD) > 0;
-			bool ScientistsAlive = Plugin.CountRoles(Smod2.API.Team.SCIENTISTS) > 0;
+			bool ScientistsAlive = Plugin.CountRoles(Smod2.API.Team.SCIENTIST) > 0;
 			bool SHAlive = Plugin.shPlayers.Count > 0;
 
 			if (MTFAlive && (CiAlive || ScpAlive || DClassAlive || SHAlive))

--- a/SerpentsHand/Plugin.cs
+++ b/SerpentsHand/Plugin.cs
@@ -190,7 +190,7 @@ namespace SerpentsHand
 		{
 			List<Player> SHPlayers = new List<Player>();
 			List<Player> CIPlayers = Playerlist;
-			for (int i = 0; i < shMaxSquad; i++)
+			for (int i = 0; i < shMaxSquad && CIPlayers.Count > 0; i++)
 			{
 				Player player = CIPlayers[rand.Next(CIPlayers.Count)];
 				SHPlayers.Add(player);


### PR DESCRIPTION
Allows SH to spawn when they are not the same size as the max spawn size and fixes enum to be up to date with Smod2 3.2.0.