### PR TITLE
uAFK replace support

### DIFF
--- a/SerpentsHand/EventHandlers.cs
+++ b/SerpentsHand/EventHandlers.cs
@@ -4,6 +4,7 @@ using MEC;
 using UnityEngine;
 using Exiled.API.Features;
 using Exiled.Events.EventArgs;
+using System.Reflection;
 
 namespace SerpentsHand
 {
@@ -220,6 +221,26 @@ namespace SerpentsHand
                 if (GetTeam(ev.NewRole) != Team.TUT)
                 {
                     shPlayers.Remove(ev.Player.Id);
+                }
+
+                if (ev.NewRole == RoleType.Spectator)
+				{
+                    object afkComp = ev.Player.GameObject.GetComponent("AFKComponent");
+                    if (afkComp != null)
+                    {
+                        if (afkComp.GetType().GetMember("PlayerToReplace").Length > 0)
+                        {
+                            Player p = (Player)((FieldInfo)afkComp.GetType().GetMember("PlayerToReplace")[0]).GetValue(afkComp);
+                            if (p != null)
+                            {
+                                Timing.CallDelayed(1f, () =>
+                                {
+                                    shPlayers.Add(p.Id);
+                                    p.Broadcast(10, SerpentsHand.instance.Config.SpawnBroadcast);
+                                });
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Using [uAFK 3.1.2](https://github.com/kingsplayground/Ultimate-AFK/releases/tag/v3.1.2), this will properly make replaced players serpents hand if they afk.