### PR TITLE
Support for RespawnTimer

### DIFF
--- a/SerpentsHand/API/SerpentsHand.cs
+++ b/SerpentsHand/API/SerpentsHand.cs
@@ -1,4 +1,4 @@
-﻿using Exiled.API.Features;
+using Exiled.API.Features;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,6 +6,11 @@ namespace SerpentsHand.API
 {
 	public static class SerpentsHand
 	{
+		public static void Spawnable()
+		{
+			EventHandlers.IsSpawnable();
+		}
+
 		public static void SpawnPlayer(Player player, bool full = true)
 		{
 			EventHandlers.SpawnPlayer(player, full);

--- a/SerpentsHand/EventHandlers.cs
+++ b/SerpentsHand/EventHandlers.cs
@@ -40,7 +40,7 @@ namespace SerpentsHand
         {
             if (ev.NextKnownTeam == Respawning.SpawnableTeamType.ChaosInsurgency)
             {
-                if (rand.Next(1, 101) <= SerpentsHand.instance.Config.SpawnChance && Player.List.Count() > 0 && respawnCount >= SerpentsHand.instance.Config.RespawnDelay)
+                if (isSpawnable && Player.List.Count() > 0 && respawnCount >= SerpentsHand.instance.Config.RespawnDelay)
                 {
                     List<Player> SHPlayers = new List<Player>();
                     List<Player> CIPlayers = new List<Player>(ev.Players);

--- a/SerpentsHand/EventHandlers.cs
+++ b/SerpentsHand/EventHandlers.cs
@@ -14,7 +14,7 @@ namespace SerpentsHand
         public static List<int> shPlayers = new List<int>();
         private List<int> shPocketPlayers = new List<int>();
 
-        private int respawnCount = 0;
+        private static int respawnCount = 0;
 
         bool test = false;
 
@@ -32,7 +32,7 @@ namespace SerpentsHand
 	    
 	public static void IsSpawnable()
         {
-            if (rand.Next(1, 101) <= SerpentsHand.instance.Config.SpawnChance) isSpawnable = true;
+            if (rand.Next(1, 101) <= SerpentsHand.instance.Config.SpawnChance && respawnCount >= SerpentsHand.instance.Config.RespawnDelay) isSpawnable = true;
             else isSpawnable = false;
         }
 

--- a/SerpentsHand/EventHandlers.cs
+++ b/SerpentsHand/EventHandlers.cs
@@ -9,6 +9,8 @@ namespace SerpentsHand
 {
     public partial class EventHandlers
     {
+	public static bool isSpawnable;    
+	
         public static List<int> shPlayers = new List<int>();
         private List<int> shPocketPlayers = new List<int>();
 
@@ -26,6 +28,12 @@ namespace SerpentsHand
             shPlayers.Clear();
             shPocketPlayers.Clear();
             respawnCount = 0;
+        }
+	    
+	public static void IsSpawnable()
+        {
+            if (rand.Next(1, 101) <= SerpentsHand.instance.Config.SpawnChance) isSpawnable = true;
+            else isSpawnable = false;
         }
 
         public void OnTeamRespawn(RespawningTeamEventArgs ev)

--- a/SerpentsHand/Patches/SHSpawn.cs
+++ b/SerpentsHand/Patches/SHSpawn.cs
@@ -9,7 +9,7 @@ namespace SerpentsHand.Patches
         {
             if(__result == Respawning.SpawnableTeamType.ChaosInsurgency)
             {
-                API.SerpentsHand.Spawnable();
+                EventHandlers.IsSpawnable();
             }
         }
     }

--- a/SerpentsHand/Patches/SHSpawn.cs
+++ b/SerpentsHand/Patches/SHSpawn.cs
@@ -1,0 +1,16 @@
+﻿using HarmonyLib;
+
+namespace SerpentsHand.Patches
+{
+    [HarmonyPatch(typeof(Respawning.RespawnTickets), nameof(Respawning.RespawnTickets.DrawRandomTeam))]
+    class SHSpawn
+    {
+        public static void Postfix(ref Respawning.SpawnableTeamType __result)
+        {
+            if(__result == Respawning.SpawnableTeamType.ChaosInsurgency)
+            {
+                API.SerpentsHand.Spawnable();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Right now, it is impossible to make my RespawnTimer plugin work with SerpentsHand, because the SerpentsHand's respawn chance is decided at the exact same moment when the CI spawns.

I did, that this chance is decided, when CI's Car moves, giving me a chance to make it compatibile with my plugin.

I hope I didn't screw up something, I tested many times and it worked.