### PR TITLE
Spawning rework

### DIFF
--- a/SerpentsHand/EventHandlers.cs
+++ b/SerpentsHand/EventHandlers.cs
@@ -32,9 +32,12 @@ namespace SerpentsHand
 
         public void OnTeamRespawn(RespawningTeamEventArgs ev)
         {
-            if (serpentsRespawnCount < SerpentsHand.instance.Config.MaxSpawns && !(!SerpentsHand.instance.Config.CanSpawnWithoutSCPs && Player.List.Where(x => x.Team == Team.SCP).Count() == 0))
+            if (serpentsRespawnCount < SerpentsHand.instance.Config.MaxSpawns && 
+                Player.List.Count(p => p.Team == Team.SCP && (p.Role != RoleType.Scp0492 || 
+                (p.SessionVariables.ContainsKey("is966") && (bool)p.SessionVariables["is966"]))) >= 2 &&
+                (Player.List.Count(p => p.IsHuman) > 6))
             {
-                if (rand.Next(1, 101) <= SerpentsHand.instance.Config.SpawnChance && Player.List.Count() > 0 && teamRespawnCount >= SerpentsHand.instance.Config.RespawnDelay)
+                if (rand.Next(1, 101) <= SerpentsHand.instance.Config.SpawnChance)
                 {
                     if (ev.NextKnownTeam == Respawning.SpawnableTeamType.NineTailedFox)
                     {

--- a/SerpentsHand/Logic.cs
+++ b/SerpentsHand/Logic.cs
@@ -127,7 +127,7 @@ namespace SerpentsHand
             }
             else
             {
-                player.Position = RoleType.Scp096.GetRandomSpawnPoint();
+                player.Position = Exiled.API.Extensions.Role.GetRandomSpawnPoint(RoleType.Scp096);
             }
         }
 

--- a/SerpentsHand/packages.config
+++ b/SerpentsHand/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EXILED" version="2.1.30" targetFramework="net472" />
+  <package id="EXILED" version="2.11.1" targetFramework="net472" />
 </packages>

--- a/SerpentsHand/packages.config
+++ b/SerpentsHand/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EXILED" version="2.8.0" targetFramework="net472" />
+  <package id="EXILED" version="2.1.30" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
Spawning reworked to >= 2 SCPs alive (not including zombies) and > 6 humans alive (not including tutorials)